### PR TITLE
Polish behaviour: allow no params, exclude examples from validation

### DIFF
--- a/src/swagger_endpoints.erl
+++ b/src/swagger_endpoints.erl
@@ -144,12 +144,6 @@ response(StatusCode, Resp, Options, OASVersion) ->
       {Code, Schema}
   end .
 
-params_to_json_schema([], Options, _OASVersion) ->
-  rebar_api:error("~p: use YAML array for parameters not JSON array!",
-                  [proplists:get_value(endpoint, Options)]),
-  [];
-params_to_json_schema(null, _Options, _OASVersion) ->
-  [];
 params_to_json_schema(Params, Options, OASVersion) ->
   [ case proplists:get_value("$ref", Param, none) of
       none ->

--- a/src/swagger_generate.erl
+++ b/src/swagger_generate.erl
@@ -50,7 +50,7 @@ template_code() ->
           path(Method, OperationId, Args) ->
              begin
                #{path := Endpoint, parameters := Parameters} = maps:get(Method, operation(OperationId)),
-               InPath = [ Param || Param <- Parameters, lists:member({"in", "path"}, Param) ],
+               InPath = [ Param || Param <- Parameters, lists:member({"in", "path", "example"}, Param) ],
                lists:foldl(fun(Param, Path) -> 
                                Name = proplists:get_value("name", Param),
                                case {proplists:get_value("required", Param, false),


### PR DESCRIPTION
This PR provides some small polish of the behaviour. It:

* Disables the warning when a request does not have any parameters

* Allows definitions to have an example
