### PR TITLE
Allow reusable params

### DIFF
--- a/test/swagger_endpoints_tests.erl
+++ b/test/swagger_endpoints_tests.erl
@@ -20,10 +20,10 @@ from_yaml_test_() ->
           application:stop(yamerl)
       end,
      [ {"Parses single definition", fun parses_single_definition/0}
-      , {"Parses various definitions", fun parses_definitions/0}
-      , {"Parses single endpoint and a definition", fun parses_single_endpoint/0}
-      , {"Parses complex scenario", fun parses_complex_scenario/0}
-      , {"Parses swagger.yaml from aeternity/aeternity", fun parses_swagger_yaml/0}
+     , {"Parses various definitions", fun parses_definitions/0}
+     , {"Parses single endpoint and a definition", fun parses_single_endpoint/0}
+     , {"Parses complex scenario", fun parses_complex_scenario/0}
+     , {"Parses swagger.yaml from aeternity/aeternity", fun parses_swagger_yaml/0}
       ]}.
 
 parses_single_definition() ->
@@ -225,9 +225,16 @@ parses_complex_scenario() ->
 
 parses_swagger_yaml() ->
     [V2Yaml] = yamerl_constr:file("test/swagger_v2.yaml"),
-    V2 = swagger_endpoints:from_yaml(V2Yaml, []),
+    {_V2Defs, _V2, _} = swagger_endpoints:from_yaml(V2Yaml, []),
     [V3Yaml] = yamerl_constr:file("test/swagger_v3.yaml"),
-    V3 = swagger_endpoints:from_yaml(V3Yaml, []),
+    {_V3Defs, V3, _V3Prefix} = swagger_endpoints:from_yaml(V3Yaml, []),
+    %% ensure we've parsed the param from #/components/parameters/
+    #{get := #{parameters := [[{"in","query"},
+                               {"name","big-int-as-string"},
+                               {"description",
+                               "If this flag is set to true, the response will have all integers set as strings"},
+                               {"required",false},
+                               {"type","boolean"}]]}} = maps:get('GetTopBlock', V3),
     ok.
 
 yaml(Opts) ->

--- a/test/swagger_v3.yaml
+++ b/test/swagger_v3.yaml
@@ -40,7 +40,7 @@ paths:
       operationId: GetTopBlock
       description: Get the top block (either key or micro block)
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIntAsStringParam'
       responses:
         "200":
           description: Successful operation
@@ -3437,10 +3437,9 @@ components:
         - auth_data
         - tx
   parameters:
-    bigIngAsStringParam:
+    bigIntAsStringParam:
       in: query
       name: "big-int-as-string"
       description: 'If this flag is set to true, the response will have all integers set as strings'
       required: false
       type: boolean
-

--- a/test/swagger_v3.yaml
+++ b/test/swagger_v3.yaml
@@ -39,6 +39,8 @@ paths:
         - chain
       operationId: GetTopBlock
       description: Get the top block (either key or micro block)
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       responses:
         "200":
           description: Successful operation
@@ -3434,3 +3436,11 @@ components:
         - fee
         - auth_data
         - tx
+  parameters:
+    bigIngAsStringParam:
+      in: query
+      name: "big-int-as-string"
+      description: 'If this flag is set to true, the response will have all integers set as strings'
+      required: false
+      type: boolean
+


### PR DESCRIPTION
This allows us to have [reusable params](https://swagger.io/docs/specification/describing-parameters/) (section `Common Parameters for Various Paths`)